### PR TITLE
use game location when launching

### DIFF
--- a/launcher/PlaceholderCLILauncher/launcher.bat
+++ b/launcher/PlaceholderCLILauncher/launcher.bat
@@ -4,6 +4,8 @@ setlocal enabledelayedexpansion
 :: Set the game executable
 set GAME_EXECUTABLE=PVZ.Main_Win64_Retail.exe
 
+@FOR /f "tokens=3*" %%i in ('Reg Query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\PopCap\Plants vs Zombies Garden Warfare" /v "Install Dir" 2^>Nul') do Set "GAME_PATH=%%j"
+
 :menu
 echo ========================
 echo        Game Launcher
@@ -32,7 +34,7 @@ set /p port=Enter port:
 set /p maxplayers=Enter maxplayers:
 set /p modpack=Enter Modpack (leave blank for none):
 echo Starting game as Host with username %servername% and modpack %modpack%...
-%GAME_EXECUTABLE% --host --servername --port %port% %servername% --maxplayers %maxplayers% --modpack %modpack%
+"%GAME_PATH%%GAME_EXECUTABLE%" --host --servername --port %port% %servername% --maxplayers %maxplayers% --modpack %modpack%
 exit
 
 :join
@@ -41,5 +43,5 @@ set /p ip=Enter IP address:
 set /p port=Enter Port:
 set /p modpack=Enter Modpack (leave blank for none):
 echo Joining game at %ip%:%port% with username %username% and modpack %modpack%...
-%GAME_EXECUTABLE% --join %ip% --port %port% --username %username% --modpack %modpack%
+"%GAME_PATH%%GAME_EXECUTABLE%" --join %ip% --port %port% --username %username% --modpack %modpack%
 exit

--- a/launcher/RushedQTLauncher/main.cpp
+++ b/launcher/RushedQTLauncher/main.cpp
@@ -13,6 +13,7 @@
 #include <QFileDialog>
 #include <QProcess>
 #include <QMessageBox>
+#include <QSettings>
 
 int main(int argc, char *argv[])
 {
@@ -70,12 +71,8 @@ int main(int argc, char *argv[])
     mainLayout->addLayout(buttonLayout); // Add button layout
     mainLayout->addWidget(stackedWidget);
 
-    // Ask the user for the path to the .exe file at startup
-    QString exePath = QFileDialog::getOpenFileName(&w, "Select Executable", QString(), "*.exe");
-    if (exePath.isEmpty()) {
-        QMessageBox::critical(&w, "Error", "No executable selected, the program will now exit.");
-        return -1; // Exit if no file is selected
-    }
+    QSettings gameRegistryItem("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\PopCap\\Plants vs Zombies Garden Warfare", QSettings::NativeFormat);
+    QString exePath = gameRegistryItem.value("Install Dir").toString() + "PVZ.Main_Win64_Retail.exe";
 
     QObject::connect(hostButton, &QPushButton::clicked, [&](){
         // Launch the .exe file with command line args when "Host" button is clicked


### PR DESCRIPTION
You can find where the game is installed by looking at registry at: `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\PopCap\Plants vs Zombies Garden Warfare` within "Install Dir".
I updated the CLI and QT launcher to use the location found in the registry.